### PR TITLE
Update us-states.json

### DIFF
--- a/data/us-states.json
+++ b/data/us-states.json
@@ -2031,7 +2031,7 @@
     },
     {
       "type": "Feature",
-      "id": "IW",
+      "id": "IA",
       "properties": { "name": "Iowa", "density": 54.81 },
       "geometry": {
         "type": "Polygon",


### PR DESCRIPTION
In the us-states.json file the state abbreviation for Iowa should be IA, not IW.